### PR TITLE
network config is deprecated

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,5 +40,5 @@ services:
 # Use the same external network in $upstream containers.
 networks:
   default:
-    external:
-      name: www-network
+    name: www-network
+    external: true


### PR DESCRIPTION
Message: WARN[0000] network default: network.external.name is deprecated. Please set network.name with external: true